### PR TITLE
Fix docker compose up not replacing previous revision

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,20 @@
 services:
   # @TODO: Database credentials should be passed as environment variables
   apuopere-backend:
-    container_name: apuopere-backend
     environment:
-        SPRING_API_URL: ${APP_URL_DEV}
-        SPRING_DATASOURCE_URL: ${POSTGRES_URL}
-        SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
-        SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
-        SPRING_JPA_HIBERNATE_DDL_AUTO: none
-        SPRING_PROFILES_ACTIVE: docker
-        SPRING_MAIL_HOST: smtp.gmail.com
-        SPRING_MAIL_PORT: 587
-        SPRING_MAIL_USERNAME: mail.apuopere@gmail.com
-        SPRING_MAIL_PASSWORD: tsnbgijhjtetbonu
-        SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
-        SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
-        SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_REQUIRED: "true"
+      SPRING_API_URL: ${APP_URL_DEV}
+      SPRING_DATASOURCE_URL: ${POSTGRES_URL}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: none
+      SPRING_PROFILES_ACTIVE: docker
+      SPRING_MAIL_HOST: smtp.gmail.com
+      SPRING_MAIL_PORT: 587
+      SPRING_MAIL_USERNAME: mail.apuopere@gmail.com
+      SPRING_MAIL_PASSWORD: tsnbgijhjtetbonu
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_REQUIRED: "true"
     build: .
     ports:
       - "8080:8080"
@@ -35,7 +34,7 @@ services:
     ports:
       - "5434:5432"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -d apuope_db -U apuope_user" ]
+      test: ["CMD-SHELL", "pg_isready -d apuope_db -U apuope_user"]
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Removing preset container name from backend container. Should fix the issue with `docker compose up` not working properly if previous containers exist.