### PR TITLE
 TASK 31: Delete conversation, backend

### DIFF
--- a/src/main/java/com/apuope/apuope_re/controllers/ChatbotController.java
+++ b/src/main/java/com/apuope/apuope_re/controllers/ChatbotController.java
@@ -40,4 +40,11 @@ public class ChatbotController {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION).replace("Bearer ", "");
         return ResponseEntity.ok(chatbotService.sendRequest(token, request, input));
     }
+
+    @GetMapping(value = "/deleteConversation/{id}")
+    public ResponseEntity<ResponseData<String>> deleteConversation(@PathVariable("id") Integer conversationId) {
+        ResponseData<String> response = chatbotService.deleteConversation(conversationId);
+
+        return response.getSuccess() ? ResponseEntity.ok(response) : ResponseEntity.internalServerError().body(response);
+    }
 }

--- a/src/main/java/com/apuope/apuope_re/jooq/tables/Message.java
+++ b/src/main/java/com/apuope/apuope_re/jooq/tables/Message.java
@@ -71,7 +71,7 @@ public class Message extends TableImpl<MessageRecord> {
     /**
      * The column <code>apuope.message.content</code>.
      */
-    public final TableField<MessageRecord, String> CONTENT = createField(DSL.name("content"), SQLDataType.VARCHAR(1000).nullable(false), this, "");
+    public final TableField<MessageRecord, String> CONTENT = createField(DSL.name("content"), SQLDataType.CLOB.nullable(false), this, "");
 
     /**
      * The column <code>apuope.message.source</code>.

--- a/src/main/java/com/apuope/apuope_re/repositories/ConversationRepository.java
+++ b/src/main/java/com/apuope/apuope_re/repositories/ConversationRepository.java
@@ -49,6 +49,19 @@ public class ConversationRepository {
                 .fetchInto(MessageData.class);
     }
 
+    public boolean deleteConversationById(Integer conversationId, DSLContext context){
+        int affectedRows = context.delete(Message.MESSAGE)
+                 .where(Message.MESSAGE.CONVERSATION_ID.eq(conversationId))
+                 .execute();
+
+        affectedRows += context.delete(Conversation.CONVERSATION)
+                .where(Conversation.CONVERSATION.ID.eq(conversationId))
+                .execute();
+
+
+        return affectedRows > 0;
+    }
+
     public ConversationRecord findLatestByAccountId(Integer accountId, DSLContext context){
         return context.selectFrom(Conversation.CONVERSATION)
                 .where(Conversation.CONVERSATION.ACCOUNT_ID.eq(accountId))

--- a/src/main/java/com/apuope/apuope_re/repositories/UserRepository.java
+++ b/src/main/java/com/apuope/apuope_re/repositories/UserRepository.java
@@ -55,7 +55,7 @@ public class UserRepository {
     }
 
     public Boolean alterUserVerify(UUID uuid, DSLContext context) {
-        int affectedRows =  context.update(Users.USERS)
+        int affectedRows = context.update(Users.USERS)
                 .set(Users.USERS.VERIFIED, true)
                 .set(Users.USERS.UPDATED, LocalDateTime.now(TIMEZONE))
                 .where(Users.USERS.UUID.eq(uuid)).and(Users.USERS.VERIFIED.eq(false))
@@ -65,7 +65,7 @@ public class UserRepository {
     }
 
     public Boolean alterUserResetPassword(Integer id, String passwordHash, DSLContext context) {
-        int affectedRows =  context.update(Users.USERS)
+        int affectedRows = context.update(Users.USERS)
                 .set(Users.USERS.PASSWORD_HASH, passwordHash)
                 .set(Users.USERS.UPDATED, LocalDateTime.now(TIMEZONE))
                 .where(Users.USERS.ID.eq(id))

--- a/src/main/java/com/apuope/apuope_re/services/ChatbotService.java
+++ b/src/main/java/com/apuope/apuope_re/services/ChatbotService.java
@@ -63,6 +63,15 @@ public class ChatbotService {
         return conversationRepository.fetchConversationById(conversationId, dslContext);
     }
 
+    public ResponseData<String> deleteConversation(Integer conversationId) {
+        boolean deleted = conversationRepository.deleteConversationById(conversationId, dslContext);
+
+        if (deleted) {
+            return new ResponseData<>(true, "Conversation deleted.");
+        }
+        return new ResponseData<>(false, "Conversation deletion failed.");
+    }
+
     public ConversationRecord startConversation(Integer userId, ChatRequestData request) {
         return conversationRepository.createConversation(userId, request.getChapterId(), "", dslContext);
     }

--- a/src/main/resources/db/migration/V8__alter_message_table.sql
+++ b/src/main/resources/db/migration/V8__alter_message_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE apuope.message
+ALTER COLUMN content TYPE TEXT;


### PR DESCRIPTION
Ticket: https://github.com/orgs/APUOPE-RE/projects/3/views/1?pane=issue&itemId=85665898&issue=APUOPE-RE%7Cbackend%7C31

- Created an endpoint to call conversation deletion method
    - Takes conversation id as a parameter
- Created a method that calls chat bot repository to remove conversation
- In chat bot repository created query which first deletes messages of a conversation and then conversation

Also edited the message table's content (the message text) in db to type TEXT so the length isn't restricted. 